### PR TITLE
The init function returns the used `now` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 It is possible to use the following configurations at every setup level; in a `setupJest.js` file as well as in a `beforeEach` or a `test` function as shown [here](__tests__/index.test.js).
 
 ```javascript
-require('jest-mock-now')();
+const timestamp = require('jest-mock-now')();
 
 console.log(Date.now()); // 1479427200000
 ```
@@ -23,9 +23,16 @@ or
 ```javascript
 const now = new Date('2017-06-22');
 
-require('jest-mock-now')(now);
+console.log(Date.now()); // 149808960000
+```
 
-console.log(Date.now()); // 1498089600000
+The `jest-mock-now` function returns the timestamp used to mock the `Date.now` method:
+
+```javascript
+const timestamp = require('jest-mock-now')(new Date('2017-06-22'));
+
+console.log(timestamp); // 1498089600000
+console.log(Date.now()); // 149808960000
 ```
 
 If you need to restore the original `Date.now()` method, you can call `mockRestore()`.

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -13,6 +13,12 @@ test('Date.now() to match snapshot w/o options', () => {
   expect(Date.now()).toMatchSnapshot();
 });
 
+test('init function returns the used `now` value', () => {
+  expect(index()).toEqual(NOW);
+  const now = new Date('2017-06-22');
+  expect(index(now)).toEqual(now.getTime());
+});
+
 test('Date.now() to match snapshot w/ options', () => {
   const now = new Date('2017-06-22');
   index(now);

--- a/index.js
+++ b/index.js
@@ -3,4 +3,5 @@ const { NOW } = require('./constants');
 module.exports = date => {
   const now = date ? date.getTime() : NOW;
   Date.now = jest.spyOn(Date, 'now').mockImplementation(() => now);
+  return now;
 };


### PR DESCRIPTION
This is a simple change that allows to:

```js
const now = require("jest-mock-now")();

...
expect(object.created_at).toBe(now);
```